### PR TITLE
ignoring .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 _site_local
 .DS_Store
 reference/cmsis-plus/
+.jekyll-metadata


### PR DESCRIPTION
## What/why?

This helps Jekyll keep track of which files have not been modified since the site was last built, and which files will need to be regenerated on the next build. This file will not be included in the generated site. It’s probably a good idea to add this to your .gitignore file.
http://jekyllrb.com/docs/structure/
