### PR TITLE
Locking Rubby Gems versions for use in a variety of environments.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,15 @@
 source "https://rubygems.org"
 
-# Run `bundle install` to update gems.
-
-gem 'jekyll'
+gem 'jekyll', '=3.2.1', :platforms => [:ruby, :x64_mingw, :mswin]
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
 group :jekyll_plugins do
   gem 'jekyll-watch'
-  gem 'jekyll-last-modified-at'
-  # gem 'jekyll-multiple-languages'
-  gem 'jekyll-mentions'
   gem 'jemoji'
-  gem 'jekyll-redirect-from'
-  gem 'jekyll-sitemap'
   gem 'jekyll-paginate'
+  gem 'jekyll-last-modified-at', '>=1.0.0',  :platforms => [:ruby, :x64_mingw, :mswin]
+  gem 'jekyll-mentions', '=1.1.3',  :platforms => [:ruby, :x64_mingw, :mswin]
+  gem 'jekyll-redirect-from', '=0.11.0',  :platforms => [:ruby, :x64_mingw, :mswin]
+  gem 'jekyll-sitemap', '=0.11.0',  :platforms => [:ruby, :x64_mingw, :mswin]
+  # gem 'jekyll-multiple-languages'
 end


### PR DESCRIPTION
# What/why?

In my development environment I have several projects each one works with a different version of gems which sometimes leaves me in doubt if it is the version that is causing a certain bug, to avoid this, I fixed the versions of the gems where I identified that it would be important In rich versions environments.

I recreate the pull-request, because I renamed the branch the pull-request #25 was close by github automatically, 

# How was it tested?

bundle update
bundle exec jekyll s