### PR TITLE
Ignore eclipse project config files and temp gemfies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ _site_local
 .DS_Store
 reference/cmsis-plus/
 .jekyll-metadata
+*~
+/.Gemfile.un~
+/Gemfile~
+/.project
+/.settings/


### PR DESCRIPTION
## What/why?

Since I use Eclipse to maintain my version of the site, I need to ignore it.

I have also seen garbage related to the use of gemfile.

## How was it tested?

nothink 